### PR TITLE
Use the host application's `translate_error/1` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,12 @@ Add formulator to your list of dependencies in `mix.exs`:
   $ mix deps.get
 ```
 
-Tell formulator where to find your translations
+Formulator needs to know what module to use for the `translate_error/1`
+function. This is commonly defined by Phoenix either in
+`web/views/error_helper.ex` or `web/gettext.ex`.
 ```
   # config/config.exs
-  config :formulator, gettext: YourAppName.Gettext
+  config :formulator, translate_error_module: YourAppName.Gettext
 ```
 
 You can import the package into all your views or individually as it makes

--- a/lib/formulator.ex
+++ b/lib/formulator.ex
@@ -98,17 +98,21 @@ defmodule Formulator do
     "data-role": "#{field}-error"
   end
 
-  def translate_error({msg, opts}) do
-    case opts[:count] do
-      nil -> Gettext.dgettext(gettext, "errors", msg, opts)
-      count -> Gettext.dngettext(gettext, "errors", msg, msg, count, opts)
+  @error_message """
+    Missing translate_error_module config. Add the following to your config/config.exe
+
+    config :formulator, translate_error_module: YourAppName.Gettext
+  """
+
+  defp translate_error(error) do
+    if module = Application.get_env(:formulator, :translate_error_module) do
+      module.translate_error(error)
+    else
+      raise ArgumentError, message: @error_message
     end
   end
 
   defp input_function(:textarea), do: :textarea
   defp input_function(input_type), do: :"#{input_type}_input"
 
-  defp gettext do
-    Application.get_env(:formulator, :gettext)
-  end
 end


### PR DESCRIPTION
This fixes #5 

This function was identical to what is generated by phoenix so it doesn't make sense for us to redefine it.