### PR TITLE
Allow passing options down to the label input

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Add formulator to your list of dependencies in `mix.exs`:
 ```elixir
   def deps do
     [
-      {:formulator, "~> 0.0.4"},
+      {:formulator, "~> 0.0.5"},
     ]
   end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,6 @@
 defmodule Formulator.Mixfile do
   use Mix.Project
-  @version "0.0.4"
+  @version "0.0.5"
 
   def project do
     [app: :formulator,

--- a/test/formulator_test.exs
+++ b/test/formulator_test.exs
@@ -11,9 +11,9 @@ defmodule FormulatorTest do
       assert label |> to_string == ~s(<label for="_name">Name</label>)
     end
 
-    test "passing the label text option allows for overring the label" do
+    test "passing the label: [text:] option allows for overring the label" do
       [{:safe, label} | _] = %Form{data: %{name: ""}}
-        |> Formulator.input(:name, label: "Customer Name")
+        |> Formulator.input(:name, label: [text: "Customer Name"])
 
       assert label |> to_string == ~s(<label for="_name">Customer Name</label>)
     end
@@ -23,6 +23,13 @@ defmodule FormulatorTest do
         |> Formulator.input(:last_name, label: false)
 
       assert input =~ ~s(aria-label="Last name")
+    end
+
+    test "any options passed to `label` are passed along to the label" do
+      [{:safe, label} | _] = %Form{data: %{name: ""}}
+        |> Formulator.input(:name, label: [class: "control-label"])
+
+      assert label |> to_string == ~s(<label class="control-label" for="_name">Name</label>)
     end
   end
 


### PR DESCRIPTION
This changes the interface for displaying custom label text from:
```elixir
input(form, :name, label: "Customer name")
```

to:
```elixir
input(form, :name, label: [text: "Customer name"])
```
I think it makes more sense in the case where you're customizing the label text and other things as well:
```elixir
input(form, :name, label: [text: "Customer name", class: "customer-label"])
```
