### PR TITLE
Update README to tell people to use ErrorHelpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ function. This is commonly defined by Phoenix either in
 `web/views/error_helper.ex` or `web/gettext.ex`.
 ```
   # config/config.exs
-  config :formulator, translate_error_module: YourAppName.Gettext
+  config :formulator, translate_error_module: YourAppName.ErrorHelpers
 ```
 
 You can import the package into all your views or individually as it makes


### PR DESCRIPTION
Users _probably_ want to use the ErrorHelpers module instead of the
Gettext module for translating errors. In order to help avoid confusion
for users we should use that module in our example.