### PR TITLE
Expose the `html_error `function for public use

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -2,6 +2,7 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
+config :formulator, translate_error_module: Formulator.Test.Gettext
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this
 # file won't be loaded nor affect the parent project. For this reason,

--- a/lib/formulator.ex
+++ b/lib/formulator.ex
@@ -50,14 +50,14 @@ defmodule Formulator do
 
   defp input_without_label(form, field, options) do
     options = options ++ build_aria_label(field)
-    error = html_error(form, field)
+    error = HtmlError.html_error(form, field)
     [
       build_input(form, field, options, error)
     ] ++ error.html
   end
 
   defp input_with_label(form, field, label_options, options) do
-    error = html_error(form, field)
+    error = HtmlError.html_error(form, field)
     build_html(form, field, label_options, options, error)
   end
 
@@ -97,37 +97,6 @@ defmodule Formulator do
     end
   end
 
-  defp html_error(form, field) do
-    case form.errors[field] do
-      nil ->
-        %HtmlError{}
-      error ->
-        %HtmlError{class: "has-error", html: build_html(error, field)}
-    end
-  end
-
-  defp build_html(error, field) do
-    content_tag :span,
-    translate_error(error),
-    class: "field-error",
-    "data-role": "#{field}-error"
-  end
-
-  @error_message """
-    Missing translate_error_module config. Add the following to your config/config.exe
-
-    config :formulator, translate_error_module: YourAppName.Gettext
-  """
-
-  defp translate_error(error) do
-    if module = Application.get_env(:formulator, :translate_error_module) do
-      module.translate_error(error)
-    else
-      raise ArgumentError, message: @error_message
-    end
-  end
-
   defp input_function(:textarea), do: :textarea
   defp input_function(input_type), do: :"#{input_type}_input"
-
 end

--- a/lib/formulator/html_builder.ex
+++ b/lib/formulator/html_builder.ex
@@ -1,0 +1,24 @@
+defmodule Formulator.HtmlBuilder do
+  use Phoenix.HTML
+
+  def build_error_span(error, field) do
+    content_tag :span,
+    translate_error(error),
+    class: "field-error",
+    "data-role": "#{field}-error"
+  end
+
+  @error_message """
+    Missing translate_error_module config. Add the following to your config/config.exe
+
+    config :formulator, translate_error_module: YourAppName.Gettext
+  """
+
+  defp translate_error(error) do
+    if module = Application.get_env(:formulator, :translate_error_module) do
+      module.translate_error(error)
+    else
+      raise ArgumentError, message: @error_message
+    end
+  end
+end

--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -1,0 +1,5 @@
+if Mix.env == :test do
+  defmodule Formulator.Test.Gettext do
+    def translate_error({text, _}), do: text
+  end
+end

--- a/lib/html_error.ex
+++ b/lib/html_error.ex
@@ -3,4 +3,26 @@ defmodule Formulator.HtmlError do
     class: "",
     html: ""
   ]
+
+  @doc  """
+  Returns a struct with the appropriate error class and html for a form error.
+
+  If there are errors on the given field,
+  it will have a class to use in the form field in the `:class` field
+  and an appropriate html tag to display the error message
+  in the `:html` field.
+  """
+
+  @spec html_error(Phoenix.HTML.Form.t, atom) :: %__MODULE__{}
+  def html_error(form, field) do
+    case form.errors[field] do
+      nil ->
+        %__MODULE__{}
+      error ->
+        %__MODULE__{
+          class: "has-error",
+          html: Formulator.HtmlBuilder.build_error_span(error, field)
+        }
+    end
+  end
 end

--- a/test/html_error_test.exs
+++ b/test/html_error_test.exs
@@ -1,0 +1,26 @@
+defmodule Formulator.HtmlErrorTest do
+  use ExUnit.Case
+  alias Phoenix.HTML.Form
+  alias Formulator.HtmlError
+  doctest Formulator.HtmlError
+
+  describe "html_error" do
+    test "when there are no errors it returns an empty struct" do
+      form = %Form{errors: []}
+
+      assert HtmlError.html_error(form, :name) == %HtmlError{}
+    end
+
+    test "when there are errors it returns a struct with a span tag and a class" do
+      form = %Form{errors: [name: {"required", []}]}
+
+      error = HtmlError.html_error(form, :name)
+
+      assert error.class == "has-error"
+      {:safe, html} = error.html
+
+      span_tag = ~s(<span class="field-error" data-role="name-error">required</span>)
+      assert html |> to_string =~ span_tag
+    end
+  end
+end


### PR DESCRIPTION
Right now, we're not supporting a lot of inputs like radio buttons and selects. I wanted to use the error messages and logic around that for my other inputs. By extracting this to a public function, consumers can use that without us having to define a formulator wrapper for every single input type.