### PR TITLE
Move from Dict->Keyword. Update Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 **Formulator is part of the [thoughtbot Elixir family][elixir-phoenix] of projects.**
 
+> This README follows master, which may not be the currently published version.
+> Here are the [docs for the latest published version of Formulator](https://hexdocs.pm/formulator)
+
 ## Usage
 
 Formulator is a library for Phoenix to give you:

--- a/lib/formulator.ex
+++ b/lib/formulator.ex
@@ -29,6 +29,10 @@ defmodule Formulator do
       <%= input form, :email, label: [class: "control-label"] %>
       #=> <label class="control-label" for="user_email">Email</label>
       #=> <input id="user_email" name="user[email]" type="text" value="">
+
+      <%= input form, :email, class: "my-email-class", label: [class: "my-email-label-class"] %>
+      #=> <label class="my-email-label-class" for="user_email">Email</label>
+      #=> <input id="user_email" name="user[email]" type="text" value="" class="my-email-class">
   """
 
   @spec input(Phoenix.HTML.Form.t, atom, []) :: binary

--- a/lib/formulator.ex
+++ b/lib/formulator.ex
@@ -42,8 +42,8 @@ defmodule Formulator do
   end
 
   defp extract_label_options(options) do
-    label_options = Keyword.get(options, :label, [])
-    options = Keyword.delete(options, :label)
+    label_options = options |> Keyword.get(:label, [])
+    options = options |> Keyword.delete(:label)
 
     {label_options, options}
   end
@@ -79,9 +79,10 @@ defmodule Formulator do
   defp build_input(form, field, options, error) do
     input_type = options[:as] || :text
     input_class = options[:class] || ""
-    options = options
-    |> Dict.delete(:as)
-    |> Dict.put(:class, add_error_class(input_class, error.class))
+    options =
+      options
+      |> Keyword.delete(:as)
+      |> Keyword.put(:class, add_error_class(input_class, error.class))
 
     apply(Phoenix.HTML.Form, input_function(input_type), [form, field, options])
   end
@@ -93,7 +94,7 @@ defmodule Formulator do
   def build_label(form, field, label_options) do
     case label_options[:text] do
       nil -> label(form, field, label_options)
-      text -> label(form, field, text, Dict.delete(label_options, :text))
+      text -> label(form, field, text, label_options |> Keyword.delete(:text))
     end
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
-%{"earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "gettext": {:hex, :gettext, "0.11.0", "80c1dd42d270482418fa158ec5ba073d2980e3718bacad86f3d4ad71d5667679", [:mix], []},
-  "phoenix_html": {:hex, :phoenix_html, "2.6.2", "944a5e581b0d899e4f4c838a69503ebd05300fe35ba228a74439e6253e10e0c0", [:mix], [{:plug, "~> 1.0", [hex: :plug, optional: false]}]},
-  "plug": {:hex, :plug, "1.1.6", "8927e4028433fcb859e000b9389ee9c37c80eb28378eeeea31b0273350bf668b", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}]}}
+%{"earmark": {:hex, :earmark, "1.2.1", "7ad3f203ab84d31832814483c834e006cf88949f061a4b50d7e783147572280f", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.15.1", "d5f9d588fd802152516fccfdb96d6073753f77314fcfee892b15b6724ca0d596", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "gettext": {:hex, :gettext, "0.13.1", "5e0daf4e7636d771c4c71ad5f3f53ba09a9ae5c250e1ab9c42ba9edccc476263", [:mix], [], "hexpm"},
+  "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], [], "hexpm"},
+  "phoenix_html": {:hex, :phoenix_html, "2.9.3", "1b5a2122cbf743aa242f54dced8a4f1cc778b8bd304f4b4c0043a6250c58e258", [:mix], [{:plug, "~> 1.0", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
+  "plug": {:hex, :plug, "1.3.5", "7503bfcd7091df2a9761ef8cecea666d1f2cc454cbbaf0afa0b6e259203b7031", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"}}

--- a/test/formulator_test.exs
+++ b/test/formulator_test.exs
@@ -22,7 +22,7 @@ defmodule FormulatorTest do
       [{:safe, input} | _] = %Form{data: %{last_name: ""}}
         |> Formulator.input(:last_name, label: false)
 
-      assert input =~ ~s(aria-label="Last name")
+      assert input |> to_string =~ ~s(aria-label="Last name")
     end
 
     test "any options passed to `label` are passed along to the label" do
@@ -38,14 +38,14 @@ defmodule FormulatorTest do
       [_, {:safe, input} | _] = %Form{data: %{name: ""}}
         |> Formulator.input(:name, class: "customer_name")
 
-        assert input =~ ~s(class="customer_name ")
+        assert input |> to_string =~ ~s(class="customer_name ")
     end
 
     test "the :as option allows choosing an input other than text" do
       [_, {:safe, input} | _] = %Form{data: %{name: ""}}
         |> Formulator.input(:name, as: :hidden)
 
-        assert input =~ ~s(type="hidden")
+        assert input |> to_string =~ ~s(type="hidden")
     end
   end
 end


### PR DESCRIPTION
- Looks like the `Dict` module is deprecating. https://hexdocs.pm/elixir/Dict.html Changed usage from `Dict` to `Keyword`
- Updated the Readme to link to hex docs (solves #11)
- Updated the `def input` `@doc` to include another example that passes `class` to the input field.