### PR TITLE
Support other fields that don't end in input

### DIFF
--- a/lib/formulator.ex
+++ b/lib/formulator.ex
@@ -106,6 +106,10 @@ defmodule Formulator do
     end
   end
 
+  defp input_function(:checkbox), do: :checkbox
+  defp input_function(:date), do: :date_select
+  defp input_function(:datetime), do: :datetime_select
+  defp input_function(:time), do: :time_select
   defp input_function(:textarea), do: :textarea
   defp input_function(input_type), do: :"#{input_type}_input"
 end

--- a/test/formulator_test.exs
+++ b/test/formulator_test.exs
@@ -45,14 +45,62 @@ defmodule FormulatorTest do
       [_, {:safe, input} | _] = %Form{data: %{name: ""}}
         |> Formulator.input(:name, class: "customer_name")
 
-        assert input |> to_string =~ ~s(class="customer_name ")
+      assert input |> to_string =~ ~s(class="customer_name ")
     end
 
     test "the :as option allows choosing an input other than text" do
       [_, {:safe, input} | _] = %Form{data: %{name: ""}}
         |> Formulator.input(:name, as: :hidden)
 
-        assert input |> to_string =~ ~s(type="hidden")
+      assert input |> to_string =~ ~s(type="hidden")
+    end
+
+    test ":as works with checkbox" do
+      [_, {:safe, input} | _] = %Form{data: %{admin: ""}}
+        |> Formulator.input(:admin, as: :checkbox, class: "foo")
+
+      assert input |> to_string =~ ~s(type="checkbox")
+      assert input |> to_string =~ ~s(class="foo ")
+    end
+
+    test ":as works with date" do
+      [_, {:safe, input} | _] = %Form{data: %{date: DateTime.utc_now}}
+        |> Formulator.input(:date, as: :date, builder: fn b ->
+          b.(:year, [options: 2017..2021, class: "foo"])
+        end)
+
+      assert input |> to_string =~ ~s(id="_date_year")
+      assert input |> to_string =~ ~s(class="foo")
+    end
+
+    test ":as works with datetime" do
+      [_, {:safe, input} | _] = %Form{data: %{datetime: DateTime.utc_now}}
+        |> Formulator.input(:datetime, as: :datetime, builder: fn b ->
+          b.(:year, [options: 2017..2021, class: "foo"])
+        end)
+
+      input_string = input |> to_string
+
+      assert input_string =~ ~s(id="_datetime_year")
+      assert input |> to_string =~ ~s(class="foo")
+    end
+
+    test ":as works with time" do
+      [_, {:safe, input} | _] = %Form{data: %{time: DateTime.utc_now}}
+        |> Formulator.input(:time, as: :time, builder: fn b ->
+          b.(:hour, [options: 1..2, class: "foo"])
+        end)
+
+      assert input |> to_string =~ ~s(id="_time_hour")
+      assert input |> to_string =~ ~s(class="foo")
+    end
+
+    test ":as works with textarea" do
+      [_, {:safe, input} | _] = %Form{data: %{name: ""}}
+        |> Formulator.input(:name, as: :textarea, class: "foo")
+
+      assert input |> to_string =~ ~s(textarea)
+      assert input |> to_string =~ ~s(class="foo ")
     end
   end
 end


### PR DESCRIPTION
There are a handful of other fields that don't end in input. This adds
support for some of them.

This is still missing support for `radio_button` and `multiple_select`.
The former will require some additional code changes. The later may
require some additional considerations about the API. (SimpleForm
supports it as `collection`.