### PR TITLE
Switch CI setup to check if CI env var is defined vs not defined

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -3,7 +3,7 @@
 # Exit if any subcommand fails
 set -e
 
-if [ -z "$CI" ]; then
+if [ -n "$CI" ]; then
   echo "Removing previous build artifacts"
   rm -rf deps _build
   asdf install


### PR DESCRIPTION
Fixes #23 

(Or at least I think it should)