### PR TITLE
Bugfix: Skip adding validations for forms without validations

### DIFF
--- a/lib/formulator.ex
+++ b/lib/formulator.ex
@@ -139,7 +139,7 @@ defmodule Formulator do
     apply(Phoenix.HTML.Form, input_function(input_type), [form, field, options])
   end
 
-  defp add_validation_attributes(options, %{impl: impl, source: %{}} = form, field) when is_atom(impl) do
+  defp add_validation_attributes(options, %{impl: impl, source: %{validations: _}} = form, field) when is_atom(impl) do
     if option_enabled?(options, :validate, true) do
       form
       |> Phoenix.HTML.Form.input_validations(field)
@@ -151,7 +151,7 @@ defmodule Formulator do
   end
   defp add_validation_attributes(options, _, _), do: options
 
-  defp add_format_validation_attribute(options, %{impl: impl, source: %{}} = form, field) when is_atom(impl) do
+  defp add_format_validation_attribute(options, %{impl: impl, source: %{validations: _}} = form, field) when is_atom(impl) do
     with true <- option_enabled?(options, :validate_regex, true),
       {:format, regex} <- form.source.validations[field]
     do

--- a/test/formulator_test.exs
+++ b/test/formulator_test.exs
@@ -223,6 +223,19 @@ defmodule FormulatorTest do
     end
   end
 
+  describe "input - validation - conn" do
+    test "ignores validations for conn sourced forms" do
+      input =
+        %{email: "test_domain.com"}
+        |> prepare_conn_form
+        |> Formulator.input(:email_address, validate_regex: true)
+        |> extract_element(:second)
+        |> to_string
+
+      refute input =~ ~s(pattern)
+    end
+  end
+
   defp prepare_form(attrs) do
     %Form{data: attrs}
   end
@@ -244,6 +257,15 @@ defmodule FormulatorTest do
       impl: Phoenix.HTML.FormData.Ecto.Changeset,
       name: SampleSchema,
       source: apply(SampleSchema, changeset, [%SampleSchema{}, attrs])
+    }
+  end
+
+  defp prepare_conn_form(attrs) do
+    %Form{
+      data: attrs,
+      impl: Phoenix.HTML.FormData.Plug.Conn,
+      name: :conn_form,
+      source: %Plug.Conn{}
     }
   end
 end


### PR DESCRIPTION
Seems that when attempting to add a validation attribute to an input, some schemas don't have validations, so they're missing the key in the Phoenix.HTML.Form, which fails. This also fails for any `Plug.Conn`-based forms.

This will skip attempting to add those validations when there aren't any.
  