### PR TITLE
Add a wrapping div to inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ the application config.
   config :formulator,
     translate_error_module: YourAppName.ErrorHelpers,
     validate: false, # defaults to true
-    validate_regex: false  # defaults to true
+    validate_regex: false,  # defaults to true
+    wrapping_class: "input-set"  # defaults to nil
 ```
 
 You can import the package into all your views or individually as it makes

--- a/test/formulator_test.exs
+++ b/test/formulator_test.exs
@@ -5,15 +5,41 @@ defmodule FormulatorTest do
   alias Formulator.Test.SampleSchema
 
   describe "input - label" do
+    test "a wrapping div is adding for the fields" do
+      div_element =
+        %{name: ""}
+        |> prepare_form
+        |> Formulator.input(:name, wrapper_class: "my-wrapper")
+        |> extract_html
+        |> to_string
+
+      assert div_element =~ ~s(<div class="my-wrapper">)
+    end
+
+    test "allows configuring the wrapping class in the config" do
+      Application.put_env(:formulator, :wrapper_class, "config-wrapper")
+
+      div_element =
+        %{name: ""}
+        |> prepare_form
+        |> Formulator.input(:name)
+        |> extract_html
+        |> to_string
+
+      assert div_element =~ ~s(<div class="config-wrapper">)
+
+      Application.delete_env(:formulator, :wrapper_class)
+    end
+
     test "a label is created with the field name" do
       label =
         %{name: ""}
         |> prepare_form
         |> Formulator.input(:name)
-        |> extract_element(:first)
+        |> extract_html
         |> to_string
 
-      assert label == ~s(<label for="_name">Name</label>)
+      assert label =~ ~s(<label for="_name">Name</label>)
     end
 
     test "passing the label: [text:] option allows for overriding the label" do
@@ -21,10 +47,10 @@ defmodule FormulatorTest do
         %{name: ""}
         |> prepare_form
         |> Formulator.input(:name, label: [text: "Customer Name"])
-        |> extract_element(:first)
+        |> extract_html
         |> to_string
 
-      assert label == ~s(<label for="_name">Customer Name</label>)
+      assert label =~ ~s(<label for="_name">Customer Name</label>)
     end
 
     test "passing `label: false` will add `aria-label` to the input" do
@@ -32,7 +58,7 @@ defmodule FormulatorTest do
         %{last_name: ""}
         |> prepare_form
         |> Formulator.input(:last_name, label: false)
-        |> extract_element(:first)
+        |> extract_html
         |> to_string
 
       assert input =~ ~s(aria-label="Last name")
@@ -43,10 +69,10 @@ defmodule FormulatorTest do
         %{name: ""}
         |> prepare_form
         |> Formulator.input(:name, label: [class: "control-label"])
-        |> extract_element(:first)
+        |> extract_html
         |> to_string
 
-      assert label == ~s(<label class="control-label" for="_name">Name</label>)
+      assert label =~ ~s(<label class="control-label" for="_name">Name</label>)
     end
 
     test "passing the label: 'text' option allows for overriding the label" do
@@ -54,10 +80,10 @@ defmodule FormulatorTest do
         %{name: ""}
         |> prepare_form()
         |> Formulator.input(:name, label: "Customer Name")
-        |> extract_element(:first)
+        |> extract_html
         |> to_string
 
-      assert label == ~s(<label for="_name">Customer Name</label>)
+      assert label =~ ~s(<label for="_name">Customer Name</label>)
     end
   end
 
@@ -67,7 +93,7 @@ defmodule FormulatorTest do
         %{name: ""}
         |> prepare_form
         |> Formulator.input(:name, class: "customer_name")
-        |> extract_element(:second)
+        |> extract_html
         |> to_string
 
       assert input =~ ~s(class="customer_name")
@@ -78,7 +104,7 @@ defmodule FormulatorTest do
         %{name: ""}
         |> prepare_form
         |> Formulator.input(:name, as: :hidden)
-        |> extract_element(:second)
+        |> extract_html
         |> to_string
 
       assert input =~ ~s(type="hidden")
@@ -89,7 +115,7 @@ defmodule FormulatorTest do
         %{admin: ""}
         |> prepare_form()
         |> Formulator.input(:admin, as: :checkbox, class: "foo")
-        |> extract_element(:second)
+        |> extract_html
         |> to_string
 
       assert input =~ ~s(type="checkbox")
@@ -103,7 +129,7 @@ defmodule FormulatorTest do
         |> Formulator.input(:date, as: :date, builder: fn b ->
           b.(:year, [options: 2017..2021, class: "foo"])
         end)
-        |> extract_element(:second)
+        |> extract_html
         |> to_string
 
       assert input =~ ~s(id="_date_year")
@@ -117,7 +143,7 @@ defmodule FormulatorTest do
         |> Formulator.input(:datetime, as: :datetime, builder: fn b ->
           b.(:year, [options: 2017..2021, class: "foo"])
         end)
-        |> extract_element(:second)
+        |> extract_html
         |> to_string
 
       assert input =~ ~s(id="_datetime_year")
@@ -131,7 +157,7 @@ defmodule FormulatorTest do
         |> Formulator.input(:time, as: :time, builder: fn b ->
           b.(:hour, [options: 1..2, class: "foo"])
         end)
-        |> extract_element(:second)
+        |> extract_html
         |> to_string
 
       assert input =~ ~s(id="_time_hour")
@@ -143,7 +169,7 @@ defmodule FormulatorTest do
         %{name: ""}
         |> prepare_form()
         |> Formulator.input(:name, as: :textarea, class: "foo")
-        |> extract_element(:second)
+        |> extract_html
         |> to_string
 
       assert input =~ ~s(textarea)
@@ -157,7 +183,7 @@ defmodule FormulatorTest do
         %{name: "Fluff"}
         |> prepare_changeset_form(:validate)
         |> Formulator.input(:name, validate: true)
-        |> extract_element(:second)
+        |> extract_html
         |> to_string
 
       assert input =~ ~s(required)
@@ -168,7 +194,7 @@ defmodule FormulatorTest do
         %{name: "Fluff"}
         |> prepare_changeset_form(:novalidate)
         |> Formulator.input(:name, validate: true)
-        |> extract_element(:second)
+        |> extract_html
         |> to_string
 
       refute input =~ ~s(required)
@@ -181,7 +207,7 @@ defmodule FormulatorTest do
         %{number: "321"}
         |> prepare_changeset_form(:validate)
         |> Formulator.input(:number, validate: true)
-        |> extract_element(:second)
+        |> extract_html
         |> to_string
 
       assert input =~ ~s(min)
@@ -192,7 +218,7 @@ defmodule FormulatorTest do
         %{number: "321"}
         |> prepare_changeset_form(:novalidate)
         |> Formulator.input(:number, validate: true)
-        |> extract_element(:second)
+        |> extract_html
         |> to_string
 
       refute input =~ ~s(min)
@@ -205,7 +231,7 @@ defmodule FormulatorTest do
         %{email: "test@domain.com"}
         |> prepare_changeset_form(:validate)
         |> Formulator.input(:email_address, validate_regex: true)
-        |> extract_element(:second)
+        |> extract_html
         |> to_string
 
       assert input =~ ~s(pattern)
@@ -216,7 +242,7 @@ defmodule FormulatorTest do
         %{email: "test@domain.com"}
         |> prepare_changeset_form(:novalidate)
         |> Formulator.input(:email_address, validate_regex: true)
-        |> extract_element(:second)
+        |> extract_html
         |> to_string
 
       refute input =~ ~s(pattern)
@@ -229,7 +255,7 @@ defmodule FormulatorTest do
         %{email: "test_domain.com"}
         |> prepare_conn_form
         |> Formulator.input(:email_address, validate_regex: true)
-        |> extract_element(:second)
+        |> extract_html
         |> to_string
 
       refute input =~ ~s(pattern)
@@ -240,11 +266,7 @@ defmodule FormulatorTest do
     %Form{data: attrs}
   end
 
-  defp extract_element(form, :second) do
-    [_, {:safe, element} | _] = form
-    element
-  end
-  defp extract_element(form, :first) do
+  defp extract_html(form) do
     [{:safe, element} | _] = form
     element
   end


### PR DESCRIPTION
Per request of @creuter this wraps the input and label in a div.

You can add a class to the div using either an inline option or an config option.