### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ the application config.
     translate_error_module: YourAppName.ErrorHelpers,
     validate: false, # defaults to true
     validate_regex: false,  # defaults to true
-    wrapping_class: "input-set"  # defaults to nil
+    wrapper_class: "input-set"  # defaults to nil
 ```
 
 You can import the package into all your views or individually as it makes


### PR DESCRIPTION
Looks like `wrapper_class` was implemented, but there was one instance of `wrapping_class` used in documentation.