### PR TITLE
Fix override option for validate_regex

### DIFF
--- a/lib/formulator/input.ex
+++ b/lib/formulator/input.ex
@@ -47,7 +47,7 @@ defmodule Formulator.Input do
       Keyword.get(options, field) == false -> false
       Keyword.get(options, field) == true -> true
       Application.get_env(:formulator, field, default) == true -> true
-      true -> false
+      _ -> false
     end
   end
 

--- a/lib/formulator/input.ex
+++ b/lib/formulator/input.ex
@@ -43,10 +43,12 @@ defmodule Formulator.Input do
   defp add_format_validation_attribute(options, _, _), do: options
 
   defp option_enabled?(options, field, default) do
-    Enum.any?([
-      options[field] == true,
-      Application.get_env(:formulator, field, default) == true,
-    ])
+    cond do
+      Keyword.get(options, field) == false -> false
+      Keyword.get(options, field) == true -> true
+      Application.get_env(:formulator, field, default) == true -> true
+      true -> false
+    end
   end
 
   defp add_error_class(input_class, error_class) do

--- a/test/formulator/input_test.exs
+++ b/test/formulator/input_test.exs
@@ -154,6 +154,17 @@ defmodule Formulator.InputTest do
       assert input =~ ~s(pattern)
     end
 
+    test "when there is a validation, but validate_regex is false, does not add 'format' validation option for given form" do
+      input =
+        %{email: "test@domain.com"}
+        |> prepare_changeset_form(:validate)
+        |> Input.build_input(:email_address, validate_regex: false)
+        |> extract_html
+        |> to_string
+
+      refute input =~ ~s(pattern)
+    end
+
     test "when there's not a validation, does not add 'min' validation option for given form" do
       input =
         %{email: "test@domain.com"}

--- a/test/formulator/input_test.exs
+++ b/test/formulator/input_test.exs
@@ -119,6 +119,20 @@ defmodule Formulator.InputTest do
   end
 
   describe "build_input - validation - number" do
+    test "when there is a validation, and the application config is false, do not add validation to input" do
+      Application.put_env(:formulator, :validate, false)
+      input =
+        %{number: "321"}
+        |> prepare_changeset_form(:validate)
+        |> Input.build_input(:number, [])
+        |> extract_html
+        |> to_string
+
+      refute input =~ ~s(min)
+
+      Application.delete_env(:formulator, :validate)
+    end
+
     test "when there is a validation, adds 'min' validation option for given form" do
       input =
         %{number: "321"}
@@ -143,6 +157,20 @@ defmodule Formulator.InputTest do
   end
 
   describe "build_input - validation - format" do
+    test "when there is a validation, and the application config is false, do not add validation to input" do
+      Application.put_env(:formulator, :validate_regex, false)
+      input =
+        %{email: "test@domain.com"}
+        |> prepare_changeset_form(:validate)
+        |> Input.build_input(:email_address, [])
+        |> extract_html
+        |> to_string
+
+      refute input =~ ~s(pattern)
+
+      Application.delete_env(:formulator, :validate_regex)
+    end
+
     test "when there is a validation, adds 'format' validation option for given form" do
       input =
         %{email: "test@domain.com"}
@@ -155,6 +183,8 @@ defmodule Formulator.InputTest do
     end
 
     test "when there is a validation, but validate_regex is false, does not add 'format' validation option for given form" do
+      Application.put_env(:formulator, :validate_regex, true)
+
       input =
         %{email: "test@domain.com"}
         |> prepare_changeset_form(:validate)
@@ -163,9 +193,11 @@ defmodule Formulator.InputTest do
         |> to_string
 
       refute input =~ ~s(pattern)
+
+      Application.delete_env(:formulator, :validate_regex)
     end
 
-    test "when there's not a validation, does not add 'min' validation option for given form" do
+    test "when there's not a validation, does not add 'format' validation option for given form" do
       input =
         %{email: "test@domain.com"}
         |> prepare_changeset_form(:novalidate)


### PR DESCRIPTION
# Problem
When supplying `validate_regex: false` on the input itself, it seems to be ignored

# Solution
Looks like I made a logic error when checking if the option is enabled. When the option is `false`, it failed the condition and then moved on to check the application config, which defaults to `true` when not present.

The change is to explicitly check for `false` in the options