### PR TITLE
Update error tags for better accessibility

### DIFF
--- a/lib/formulator/html_builder.ex
+++ b/lib/formulator/html_builder.ex
@@ -1,13 +1,6 @@
 defmodule Formulator.HtmlBuilder do
   use Phoenix.HTML
 
-  def build_error_span(nil, field) do
-    content_tag :span,
-    "",
-    class: "field-error",
-    "data-role": "#{field}-error",
-    id: "#{field}-error"
-  end
   def build_error_span(error, field) do
     content_tag :span,
     translate_error(error),

--- a/lib/formulator/html_builder.ex
+++ b/lib/formulator/html_builder.ex
@@ -1,11 +1,19 @@
 defmodule Formulator.HtmlBuilder do
   use Phoenix.HTML
 
+  def build_error_span(nil, field) do
+    content_tag :span,
+    "",
+    class: "field-error",
+    "data-role": "#{field}-error",
+    id: "#{field}-error"
+  end
   def build_error_span(error, field) do
     content_tag :span,
     translate_error(error),
     class: "field-error",
-    "data-role": "#{field}-error"
+    "data-role": "#{field}-error",
+    id: "#{field}-error"
   end
 
   @error_message """

--- a/lib/formulator/input.ex
+++ b/lib/formulator/input.ex
@@ -13,7 +13,7 @@ defmodule Formulator.Input do
       |> add_format_validation_attribute(form, field)
       |> Keyword.delete(:as)
       |> Keyword.put(:class, add_error_class(input_class, error.class))
-      |> Keyword.put(:aria_describedby, "#{field}-error")
+      |> add_aria_describedby(form, field)
 
     apply(Phoenix.HTML.Form, input_function(input_type), [form, field, options])
   end
@@ -57,6 +57,13 @@ defmodule Formulator.Input do
     |> Enum.reject(&(is_nil(&1)))
     |> Enum.join(" ")
     |> String.trim
+  end
+
+  defp add_aria_describedby(options, form, field) do
+    case form.errors[field] do
+      nil -> options
+      error -> options |> Keyword.put(:aria_describedby, "#{field}-error")
+    end
   end
 
   defp build_aria_label(field) do

--- a/lib/formulator/input.ex
+++ b/lib/formulator/input.ex
@@ -13,6 +13,7 @@ defmodule Formulator.Input do
       |> add_format_validation_attribute(form, field)
       |> Keyword.delete(:as)
       |> Keyword.put(:class, add_error_class(input_class, error.class))
+      |> Keyword.put(:aria_describedby, "#{field}-error")
 
     apply(Phoenix.HTML.Form, input_function(input_type), [form, field, options])
   end

--- a/lib/html_error.ex
+++ b/lib/html_error.ex
@@ -17,10 +17,7 @@ defmodule Formulator.HtmlError do
   def html_error(form, field) do
     case form.errors[field] do
       nil ->
-        %__MODULE__{
-          class: nil,
-          html: Formulator.HtmlBuilder.build_error_span(nil, field)
-        }
+        %__MODULE__{}
       error ->
         %__MODULE__{
           class: "has-error",

--- a/lib/html_error.ex
+++ b/lib/html_error.ex
@@ -17,7 +17,10 @@ defmodule Formulator.HtmlError do
   def html_error(form, field) do
     case form.errors[field] do
       nil ->
-        %__MODULE__{}
+        %__MODULE__{
+          class: nil,
+          html: Formulator.HtmlBuilder.build_error_span(nil, field)
+        }
       error ->
         %__MODULE__{
           class: "has-error",

--- a/test/html_error_test.exs
+++ b/test/html_error_test.exs
@@ -5,16 +5,10 @@ defmodule Formulator.HtmlErrorTest do
   doctest Formulator.HtmlError
 
   describe "html_error" do
-    test "when there are no errors it returns a struct with an empty span tag" do
+    test "when there are no errors it returns an empty struct" do
       form = %Form{errors: []}
 
-      error = HtmlError.html_error(form, :name)
-
-      refute error.class == "has-error"
-      {:safe, html} = error.html
-
-      span_tag = ~s(<span id="name-error" class="field-error" data-role="name-error"></span>)
-      assert html |> to_string =~ span_tag
+      assert HtmlError.html_error(form, :name) == %HtmlError{}
     end
 
     test "when there are errors it returns a struct with a span tag and a class" do
@@ -25,7 +19,7 @@ defmodule Formulator.HtmlErrorTest do
       assert error.class == "has-error"
       {:safe, html} = error.html
 
-      span_tag = ~s(<span id="name-error" class="field-error" data-role="name-error">required</span>)
+      span_tag = ~s(<span class="field-error" data-role="name-error" id="name-error">required</span>)
       assert html |> to_string =~ span_tag
     end
   end

--- a/test/html_error_test.exs
+++ b/test/html_error_test.exs
@@ -5,10 +5,16 @@ defmodule Formulator.HtmlErrorTest do
   doctest Formulator.HtmlError
 
   describe "html_error" do
-    test "when there are no errors it returns an empty struct" do
+    test "when there are no errors it returns a struct with an empty span tag" do
       form = %Form{errors: []}
 
-      assert HtmlError.html_error(form, :name) == %HtmlError{}
+      error = HtmlError.html_error(form, :name)
+
+      refute error.class == "has-error"
+      {:safe, html} = error.html
+
+      span_tag = ~s(<span id="name-error" class="field-error" data-role="name-error"></span>)
+      assert html |> to_string =~ span_tag
     end
 
     test "when there are errors it returns a struct with a span tag and a class" do
@@ -19,7 +25,7 @@ defmodule Formulator.HtmlErrorTest do
       assert error.class == "has-error"
       {:safe, html} = error.html
 
-      span_tag = ~s(<span class="field-error" data-role="name-error">required</span>)
+      span_tag = ~s(<span id="name-error" class="field-error" data-role="name-error">required</span>)
       assert html |> to_string =~ span_tag
     end
   end


### PR DESCRIPTION
# Problem
Currently, error tags are not tied to their inputs when using assistive technology such as a screen reader. Additionally, they are only output if there is an actual error, but outputting an empty error tag can be useful for validating fields on the client-side and ensuring that they are still accessible.

# Solution
This PR:

* Adds an `id` to the error tag
* Adds the `aria-describedby` attribute to the input, which points to the error tag's `id`
* Renders an empty error tag if there are no errors
* Updates tests for `html_error`

Please let me know if you have any feedback or suggestions, or don't feel like this is the right addition to the library.