### PR TITLE
Adds tags to releases

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -11,4 +11,6 @@ git add mix.exs
 git add doc
 
 git commit -m "Release version $release_version"
+git tag "v$release_version"
+git push origin "v$release_version"
 mix do hex.build, hex.publish


### PR DESCRIPTION
Closes https://github.com/thoughtbot/formulator/issues/38

What changed?
=============

We have a `bin/release` script that will set the new release version and publish the package to hex.

We also want to create a tag and push it to GitHub so releases are easier to track. This commit adds a simple tag to the release script and pushes it to GitHub.