### PR TITLE
Only add `aria-label` if label is set to false

### DIFF
--- a/lib/formulator.ex
+++ b/lib/formulator.ex
@@ -107,7 +107,7 @@ defmodule Formulator do
     {label_options, options} = extract_label_options(options)
 
     input_wrapper form, field, options, label_options, fn error ->
-      build_input(form, field, options, error)
+      build_input(form, field, options, label_options, error)
     end
   end
 

--- a/lib/formulator/input.ex
+++ b/lib/formulator/input.ex
@@ -2,8 +2,8 @@ defmodule Formulator.Input do
   use Phoenix.HTML
   alias Formulator.HtmlError
 
-  def build_input(form, field, options, error \\ %HtmlError{}) do
-    options = options ++ build_aria_label(field)
+  def build_input(form, field, options, label_options, error \\ %HtmlError{}) do
+    options = options ++ build_aria_label(field, label_options)
     input_type = options[:as] || :text
     input_class = options[:class] || ""
 
@@ -66,8 +66,11 @@ defmodule Formulator.Input do
     end
   end
 
-  defp build_aria_label(field) do
-    ["aria-label": format_label(field)]
+  defp build_aria_label(field, label_options) do
+    cond do
+      label_options == false -> ["aria-label": format_label(field)]
+      true -> []
+    end
   end
 
   defp format_label(field) do

--- a/test/formulator/input_test.exs
+++ b/test/formulator/input_test.exs
@@ -9,7 +9,7 @@ defmodule Formulator.InputTest do
       input =
         %{name: ""}
         |> prepare_form
-        |> Input.build_input(:name, class: "customer_name")
+        |> Input.build_input(:name, [class: "customer_name"], [])
         |> extract_html
         |> to_string
 
@@ -20,7 +20,7 @@ defmodule Formulator.InputTest do
       input =
         %{name: ""}
         |> prepare_form
-        |> Input.build_input(:name, as: :hidden)
+        |> Input.build_input(:name, [as: :hidden], [])
         |> extract_html
         |> to_string
 
@@ -31,7 +31,7 @@ defmodule Formulator.InputTest do
       input =
         %{admin: ""}
         |> prepare_form()
-        |> Input.build_input(:admin, as: :checkbox, class: "foo")
+        |> Input.build_input(:admin, [as: :checkbox, class: "foo"], [])
         |> extract_html
         |> to_string
 
@@ -43,9 +43,9 @@ defmodule Formulator.InputTest do
       input =
         %{date: DateTime.utc_now}
         |> prepare_form()
-        |> Input.build_input(:date, as: :date, builder: fn b ->
+        |> Input.build_input(:date, [as: :date, builder: fn b ->
           b.(:year, [options: 2017..2021, class: "foo"])
-        end)
+        end], [])
         |> extract_html
         |> to_string
 
@@ -57,9 +57,9 @@ defmodule Formulator.InputTest do
       input =
         %{datetime: DateTime.utc_now}
         |> prepare_form()
-        |> Input.build_input(:datetime, as: :datetime, builder: fn b ->
+        |> Input.build_input(:datetime, [as: :datetime, builder: fn b ->
           b.(:year, [options: 2017..2021, class: "foo"])
-        end)
+        end], [])
         |> extract_html
         |> to_string
 
@@ -71,9 +71,9 @@ defmodule Formulator.InputTest do
       input =
         %{time: DateTime.utc_now}
         |> prepare_form()
-        |> Input.build_input(:time, as: :time, builder: fn b ->
+        |> Input.build_input(:time, [as: :time, builder: fn b ->
           b.(:hour, [options: 1..2, class: "foo"])
-        end)
+        end], [])
         |> extract_html
         |> to_string
 
@@ -85,7 +85,7 @@ defmodule Formulator.InputTest do
       input =
         %{name: ""}
         |> prepare_form()
-        |> Input.build_input(:name, as: :textarea, class: "foo")
+        |> Input.build_input(:name, [as: :textarea, class: "foo"], [])
         |> extract_html
         |> to_string
 
@@ -99,7 +99,7 @@ defmodule Formulator.InputTest do
       input =
         %{name: "Fluff"}
         |> prepare_changeset_form(:validate)
-        |> Input.build_input(:name, validate: true)
+        |> Input.build_input(:name, [validate: true], [])
         |> extract_html
         |> to_string
 
@@ -110,7 +110,7 @@ defmodule Formulator.InputTest do
       input =
         %{name: "Fluff"}
         |> prepare_changeset_form(:novalidate)
-        |> Input.build_input(:name, validate: true)
+        |> Input.build_input(:name, [validate: true], [])
         |> extract_html
         |> to_string
 
@@ -124,7 +124,7 @@ defmodule Formulator.InputTest do
       input =
         %{number: "321"}
         |> prepare_changeset_form(:validate)
-        |> Input.build_input(:number, [])
+        |> Input.build_input(:number, [], [])
         |> extract_html
         |> to_string
 
@@ -137,7 +137,7 @@ defmodule Formulator.InputTest do
       input =
         %{number: "321"}
         |> prepare_changeset_form(:validate)
-        |> Input.build_input(:number, validate: true)
+        |> Input.build_input(:number, [validate: true], [])
         |> extract_html
         |> to_string
 
@@ -148,7 +148,7 @@ defmodule Formulator.InputTest do
       input =
         %{number: "321"}
         |> prepare_changeset_form(:novalidate)
-        |> Input.build_input(:number, validate: true)
+        |> Input.build_input(:number, [validate: true], [])
         |> extract_html
         |> to_string
 
@@ -162,7 +162,7 @@ defmodule Formulator.InputTest do
       input =
         %{email: "test@domain.com"}
         |> prepare_changeset_form(:validate)
-        |> Input.build_input(:email_address, [])
+        |> Input.build_input(:email_address, [], [])
         |> extract_html
         |> to_string
 
@@ -175,7 +175,7 @@ defmodule Formulator.InputTest do
       input =
         %{email: "test@domain.com"}
         |> prepare_changeset_form(:validate)
-        |> Input.build_input(:email_address, validate_regex: true)
+        |> Input.build_input(:email_address, [validate_regex: true], [])
         |> extract_html
         |> to_string
 
@@ -188,7 +188,7 @@ defmodule Formulator.InputTest do
       input =
         %{email: "test@domain.com"}
         |> prepare_changeset_form(:validate)
-        |> Input.build_input(:email_address, validate_regex: false)
+        |> Input.build_input(:email_address, [validate_regex: false], [])
         |> extract_html
         |> to_string
 
@@ -201,7 +201,7 @@ defmodule Formulator.InputTest do
       input =
         %{email: "test@domain.com"}
         |> prepare_changeset_form(:novalidate)
-        |> Input.build_input(:email_address, validate_regex: true)
+        |> Input.build_input(:email_address, [validate_regex: true], [])
         |> extract_html
         |> to_string
 
@@ -214,7 +214,7 @@ defmodule Formulator.InputTest do
       input =
         %{email: "test_domain.com"}
         |> prepare_conn_form
-        |> Input.build_input(:email_address, validate_regex: true)
+        |> Input.build_input(:email_address, [validate_regex: true], [])
         |> extract_html
         |> to_string
 

--- a/test/formulator/input_test.exs
+++ b/test/formulator/input_test.exs
@@ -92,6 +92,28 @@ defmodule Formulator.InputTest do
       assert input =~ ~s(textarea)
       assert input =~ ~s(class="foo")
     end
+
+    test "`aria-label` is not added to the input by default" do
+      input =
+        %{name: ""}
+        |> prepare_form
+        |> Input.build_input(:name, [], [])
+        |> extract_html
+        |> to_string
+
+      refute input =~ ~s(aria-label="Name")
+    end
+
+    test "passing label: false adds `aria-label` to the input" do
+      input =
+        %{name: ""}
+        |> prepare_form
+        |> Input.build_input(:name, [], false)
+        |> extract_html
+        |> to_string
+
+      assert input =~ ~s(aria-label="Name")
+    end
   end
 
   describe "build_input - validation - required" do


### PR DESCRIPTION
# Problem
[According to the docs](https://hexdocs.pm/formulator/Formulator.html#input/3-options), the `aria-label` attribute should be added when `label: false` is passed through. This is to help ensure there is a label for screen readers even in the absence of the actual `label` element.

With the current setup, however, the `aria-label` attribute is always added. Because `aria-label` takes priority over any associated `label` elements, this can lead to a less than ideal experience if a developer is also customizing the label text.

Here's a quick example:

```elixir
<%= input form, :information, label: [text: gettext("Please enter any additional information about your experience")] %>
```

And here's a simplified version of what gets generated:

```html
<div>
  <label for="survey_information">Please enter any additional information about your experience</label>
  <input id="survey_information" aria-label="Information" type="text">
</div>
```

In this example, screen readers will announce the name of the input as "Information" and ignore the `label`, which has a more descriptive name.

# Solution
This PR passes `label_options` through the `build_input` function, and then into the `build_aria_label` function. We update `build_aria_label` to only return the `aria-label` attribute if `label_options == false`.