### PR TITLE
Update Phoenix.HTML dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule Formulator.Mixfile do
   defp deps do
     [
       {:gettext, ">= 0.11.0"},
-      {:phoenix_html, "~> 2.4"},
+      {:phoenix_html, "~> 2.4 or ~> 3.0"},
       {:ex_doc, "~> 0.18", only: :dev, runtime: false},
       {:ecto, "~> 2.1", only: :test, optional: true},
       {:phoenix_ecto, "~> 3.2", only: :test, optional: true}


### PR DESCRIPTION
While Phoenix.HTML v3.0 had substantial updates around forms, none of those changes appear to impact Formulator. :tada: